### PR TITLE
Updated Reinhard Tonemapper

### DIFF
--- a/scripts/shaders/fbo_hdr.frag
+++ b/scripts/shaders/fbo_hdr.frag
@@ -13,11 +13,22 @@ uniform float exposure;
 
 layout(location = 0) out vec4 fragColor;
 
+const float Lwhite2 = 5.0; //(squared) intensity at which light is rendered white
+
+float toneMap (float luminance) {
+    return (luminance * (1.0 + (luminance / Lwhite2))) / (luminance + 1.0);
+}
+
 void main() {
 	vec3 bloom = texture(addTex1, vTexCoord).rgb/5.0 + texture(addTex2, vTexCoord).rgb/10.0 + texture(addTex3, vTexCoord).rgb/20.0 + texture(addTex4, vTexCoord).rgb/30.0 + texture(addTex5, vTexCoord).rgb/40.0;
 	vec3 color = textureLod(inputTex, vTexCoord, 0.0).rgb + max(bloom, vec3(0.0));
-	color *= 2.0/exposure;
-	color = color / (color + vec3(1.0));
-	color = pow(color, vec3(1.0/2.2));
+	color *= 1.0/exposure;
+
+	//tonemap on luminance
+	float L = length(color);
+	float scale = toneMap(L) / L;
+	color *= scale;
+
+	color = pow(color, vec3(1.0/2.2)); //linear to gamma correction
     fragColor = vec4(color,1);
 }


### PR DESCRIPTION
Reinhard Tonemapper now correctly scales all channels, rather than each individually, and uses the alternate formula that lets the colour go the white. These changes allow it to better preserve the saturation of the scene.